### PR TITLE
Fix summarize.py on macOS when awk lacks strtonum

### DIFF
--- a/scripts/IV_select.r
+++ b/scripts/IV_select.r
@@ -8,8 +8,7 @@ command<-matrix(c(
                   'coloc_res', 'r', 1, 'character', 'susie coloc result.',
                   'exp_ma_file', 'e', 1, 'character', 'input GWAS .ma file.',
                   'cells','c',1,'character','all tested cells.',
-                  'outdir','o',1,'character',"output directory.",
-                  'exposure_p_threshold','p',1,'double','exposure P-value threshold for IV filtering.'
+                  'outdir','o',1,'character',"output directory."
                   ),byrow=T,ncol=5)
 args<-getopt(command)
 if(!is.null(args$help) ){
@@ -23,7 +22,6 @@ if (file.exists(paste0(getwd(),"/",exp_ma_file))){
 }
 cells = args$cells
 outdir = args$outdir
-exposure_p_threshold <- if (is.null(args$exposure_p_threshold)) 5e-8 else as.numeric(args$exposure_p_threshold)
 ################################################
 outdir = paste0(outdir, "/MR")
 if (!dir.exists(paste0(outdir))){
@@ -40,7 +38,7 @@ tryCatch({
 confounders <- c("smoking","alcohol","education","college","university","smoke","drink","drinking")
 exp_ma_data <- fread(file = exp_ma_file, header = T, data.table = F, select = c("SNP", "P"))
 exp_ma_data <- exp_ma_data[na.omit(match(data[,8],exp_ma_data$SNP)),] %>% unique()
-exp_ma_data <- exp_ma_data[exp_ma_data$P < exposure_p_threshold,]
+exp_ma_data <- exp_ma_data[exp_ma_data$P < 5e-8,]
 #if(nrow(exp_ma_data) == 0){
 #	confounder_snps=c()
 #	print("Notice: No availuable IVs!")

--- a/scripts/IV_select.r
+++ b/scripts/IV_select.r
@@ -8,7 +8,8 @@ command<-matrix(c(
                   'coloc_res', 'r', 1, 'character', 'susie coloc result.',
                   'exp_ma_file', 'e', 1, 'character', 'input GWAS .ma file.',
                   'cells','c',1,'character','all tested cells.',
-                  'outdir','o',1,'character',"output directory."
+                  'outdir','o',1,'character',"output directory.",
+                  'exposure_p_threshold','p',1,'double','exposure P-value threshold for IV filtering.'
                   ),byrow=T,ncol=5)
 args<-getopt(command)
 if(!is.null(args$help) ){
@@ -22,6 +23,7 @@ if (file.exists(paste0(getwd(),"/",exp_ma_file))){
 }
 cells = args$cells
 outdir = args$outdir
+exposure_p_threshold <- if (is.null(args$exposure_p_threshold)) 5e-8 else as.numeric(args$exposure_p_threshold)
 ################################################
 outdir = paste0(outdir, "/MR")
 if (!dir.exists(paste0(outdir))){
@@ -38,7 +40,7 @@ tryCatch({
 confounders <- c("smoking","alcohol","education","college","university","smoke","drink","drinking")
 exp_ma_data <- fread(file = exp_ma_file, header = T, data.table = F, select = c("SNP", "P"))
 exp_ma_data <- exp_ma_data[na.omit(match(data[,8],exp_ma_data$SNP)),] %>% unique()
-exp_ma_data <- exp_ma_data[exp_ma_data$P < 5e-8,]
+exp_ma_data <- exp_ma_data[exp_ma_data$P < exposure_p_threshold,]
 #if(nrow(exp_ma_data) == 0){
 #	confounder_snps=c()
 #	print("Notice: No availuable IVs!")

--- a/scripts/clump.r
+++ b/scripts/clump.r
@@ -6,9 +6,7 @@ command<-matrix(c(
                   'exp_ma_file', 'e', 1, 'character', 'input GWAS .ma file.',
                   "snp_file",'s',1,'character','colocalized SNP list file.',
                   "ref_genotype",'r',1,'character',"provide path to reference genotype.",
-		  'duplication_path','d',1,'character','provide path to duplicated snp list. If not available input "None".',
-                  'clump_p1', 'p', 1, 'double', 'PLINK --clump-p1 threshold.',
-                  'clump_p2', 'q', 1, 'double', 'PLINK --clump-p2 threshold.'
+		  'duplication_path','d',1,'character','provide path to duplicated snp list. If not available input "None".'
                   ),byrow=T,ncol=5)
 
 args<-getopt(command)
@@ -17,17 +15,17 @@ if(!is.null(args$help) ){
         cat(paste(help,"do plink clumping from input IVs.\n"))
 }
 
-Clump <- function(exp_ma_file,ref_path,duplication_path,clump_out,clump_p1,clump_p2){
+Clump <- function(exp_ma_file,ref_path,duplication_path,clump_out){
 		if(duplication_path != paste0(getwd(),"/None")){
 			for (n in 1:22){
 				dup_snp_file = list.files(pattern = paste0("chr",n,"(\\D+|$)"), path = duplication_path, ignore.case=T)
 				plink_file = gsub("\\.bim","",list.files(pattern = paste0("chr",n,"\\D+.*bim$"), path = ref_path, ignore.case=T))
-				system(paste0('plink --silent --bfile ', ref_path, '/', plink_file,' --clump ',exp_ma_file,' --clump-field P --clump-kb 10000 --clump-p1 ', clump_p1, ' --clump-p2 ', clump_p2, ' --clump-r2 0.001 --out ',clump_out, '.chr', n,' --exclude ', duplication_path,'/',dup_snp_file))
+				system(paste0('plink --silent --bfile ', ref_path, '/', plink_file,' --clump ',exp_ma_file,' --clump-field P --clump-kb 10000 --clump-p1 5e-8 --clump-p2 0.01 --clump-r2 0.001 --out ',clump_out, '.chr', n,' --exclude ', duplication_path,'/',dup_snp_file))
 			}
 		}else{
 			for (n in 1:22){
 				plink_file = gsub("\\.bim","",list.files(pattern = paste0("chr",n,"\\D+.*bim$"), path = ref_path, ignore.case=T))
-				system(paste0('plink --silent --bfile ', ref_path, '/', plink_file,' --clump ',exp_ma_file,' --clump-field P --clump-kb 10000 --clump-p1 ', clump_p1, ' --clump-p2 ', clump_p2, ' --clump-r2 0.001 --out ',clump_out, '.chr', n))
+				system(paste0('plink --silent --bfile ', ref_path, '/', plink_file,' --clump ',exp_ma_file,' --clump-field P --clump-kb 10000 --clump-p1 5e-8 --clump-p2 0.01 --clump-r2 0.001 --out ',clump_out, '.chr', n))
 			}
 		}
 }
@@ -42,8 +40,6 @@ if (file.exists(paste0(getwd(),"/",exp_ma_file))){
 snp_file = args$snp_file
 ref_path = args$ref_genotype
 duplication_path = args$duplication_path
-clump_p1 <- if (is.null(args$clump_p1)) 5e-8 else as.numeric(args$clump_p1)
-clump_p2 <- if (is.null(args$clump_p2)) 0.01 else as.numeric(args$clump_p2)
 outdir = paste0(dirname(snp_file),'/clump')
 dir.create(outdir)
 exp_ma_data <- fread(file = exp_ma_file,header = T,data.table = F)
@@ -54,7 +50,7 @@ if (file.info(snp_file)$size == 0){
 	match <- match(snp_list, exp_ma_data$SNP) %>% na.omit
 	exp_ma_data <- exp_ma_data[match,]
 	write.table(exp_ma_data,file = paste0(outdir,'/',gsub("\\.IV", ".ma", basename(snp_file))),row.names = F,col.names = T,sep = "\t",quote = F)
-		Clump(exp_ma_file = paste0(outdir,'/',gsub("\\.IV", ".ma", basename(snp_file))), ref_path = ref_path, duplication_path = duplication_path, clump_out = paste0(dirname(snp_file),'/clump/',gsub("\\.IV", ".clump", basename(snp_file))), clump_p1 = clump_p1, clump_p2 = clump_p2)
+		Clump(exp_ma_file = paste0(outdir,'/',gsub("\\.IV", ".ma", basename(snp_file))), ref_path = ref_path, duplication_path = duplication_path, clump_out = paste0(dirname(snp_file),'/clump/',gsub("\\.IV", ".clump", basename(snp_file))))
 	df = data.frame()
 	files = list.files(outdir, pattern=paste0("^",gsub("\\.IV", "", basename(snp_file)),"\\.clump.chr.+\\.clumped$"))
 	for (file in files){

--- a/scripts/clump.r
+++ b/scripts/clump.r
@@ -6,7 +6,9 @@ command<-matrix(c(
                   'exp_ma_file', 'e', 1, 'character', 'input GWAS .ma file.',
                   "snp_file",'s',1,'character','colocalized SNP list file.',
                   "ref_genotype",'r',1,'character',"provide path to reference genotype.",
-		  'duplication_path','d',1,'character','provide path to duplicated snp list. If not available input "None".'
+		  'duplication_path','d',1,'character','provide path to duplicated snp list. If not available input "None".',
+                  'clump_p1', 'p', 1, 'double', 'PLINK --clump-p1 threshold.',
+                  'clump_p2', 'q', 1, 'double', 'PLINK --clump-p2 threshold.'
                   ),byrow=T,ncol=5)
 
 args<-getopt(command)
@@ -15,19 +17,19 @@ if(!is.null(args$help) ){
         cat(paste(help,"do plink clumping from input IVs.\n"))
 }
 
-Clump <- function(exp_ma_file,ref_path,duplication_path,clump_out){
-	if(duplication_path != paste0(getwd(),"/None")){
-		for (n in 1:22){
-			dup_snp_file = list.files(pattern = paste0("chr",n,"(\\D+|$)"), path = duplication_path, ignore.case=T)
-			plink_file = gsub("\\.bim","",list.files(pattern = paste0("chr",n,"\\D+.*bim$"), path = ref_path, ignore.case=T))
-			system(paste0('plink --silent --bfile ', ref_path, '/', plink_file,' --clump ',exp_ma_file,' --clump-field P --clump-kb 10000 --clump-p1 5e-8 --clump-p2 0.01 --clump-r2 0.001 --out ',clump_out, '.chr', n,' --exclude ', duplication_path,'/',dup_snp_file))
+Clump <- function(exp_ma_file,ref_path,duplication_path,clump_out,clump_p1,clump_p2){
+		if(duplication_path != paste0(getwd(),"/None")){
+			for (n in 1:22){
+				dup_snp_file = list.files(pattern = paste0("chr",n,"(\\D+|$)"), path = duplication_path, ignore.case=T)
+				plink_file = gsub("\\.bim","",list.files(pattern = paste0("chr",n,"\\D+.*bim$"), path = ref_path, ignore.case=T))
+				system(paste0('plink --silent --bfile ', ref_path, '/', plink_file,' --clump ',exp_ma_file,' --clump-field P --clump-kb 10000 --clump-p1 ', clump_p1, ' --clump-p2 ', clump_p2, ' --clump-r2 0.001 --out ',clump_out, '.chr', n,' --exclude ', duplication_path,'/',dup_snp_file))
+			}
+		}else{
+			for (n in 1:22){
+				plink_file = gsub("\\.bim","",list.files(pattern = paste0("chr",n,"\\D+.*bim$"), path = ref_path, ignore.case=T))
+				system(paste0('plink --silent --bfile ', ref_path, '/', plink_file,' --clump ',exp_ma_file,' --clump-field P --clump-kb 10000 --clump-p1 ', clump_p1, ' --clump-p2 ', clump_p2, ' --clump-r2 0.001 --out ',clump_out, '.chr', n))
+			}
 		}
-	}else{
-		for (n in 1:22){
-			plink_file = gsub("\\.bim","",list.files(pattern = paste0("chr",n,"\\D+.*bim$"), path = ref_path, ignore.case=T))
-			system(paste0('plink --silent --bfile ', ref_path, '/', plink_file,' --clump ',exp_ma_file,' --clump-field P --clump-kb 10000 --clump-p1 5e-8 --clump-p2 0.01 --clump-r2 0.001 --out ',clump_out, '.chr', n))
-		}
-	}
 }
 
 #cell <- strsplit(basename(snp_file),"PPH4\\.0\\.[1-9][0-9]*\\.")[[1]][2]
@@ -40,6 +42,8 @@ if (file.exists(paste0(getwd(),"/",exp_ma_file))){
 snp_file = args$snp_file
 ref_path = args$ref_genotype
 duplication_path = args$duplication_path
+clump_p1 <- if (is.null(args$clump_p1)) 5e-8 else as.numeric(args$clump_p1)
+clump_p2 <- if (is.null(args$clump_p2)) 0.01 else as.numeric(args$clump_p2)
 outdir = paste0(dirname(snp_file),'/clump')
 dir.create(outdir)
 exp_ma_data <- fread(file = exp_ma_file,header = T,data.table = F)
@@ -50,7 +54,7 @@ if (file.info(snp_file)$size == 0){
 	match <- match(snp_list, exp_ma_data$SNP) %>% na.omit
 	exp_ma_data <- exp_ma_data[match,]
 	write.table(exp_ma_data,file = paste0(outdir,'/',gsub("\\.IV", ".ma", basename(snp_file))),row.names = F,col.names = T,sep = "\t",quote = F)
-	Clump(exp_ma_file = paste0(outdir,'/',gsub("\\.IV", ".ma", basename(snp_file))), ref_path = ref_path, duplication_path = duplication_path, clump_out = paste0(dirname(snp_file),'/clump/',gsub("\\.IV", ".clump", basename(snp_file))))
+		Clump(exp_ma_file = paste0(outdir,'/',gsub("\\.IV", ".ma", basename(snp_file))), ref_path = ref_path, duplication_path = duplication_path, clump_out = paste0(dirname(snp_file),'/clump/',gsub("\\.IV", ".clump", basename(snp_file))), clump_p1 = clump_p1, clump_p2 = clump_p2)
 	df = data.frame()
 	files = list.files(outdir, pattern=paste0("^",gsub("\\.IV", "", basename(snp_file)),"\\.clump.chr.+\\.clumped$"))
 	for (file in files){
@@ -63,4 +67,3 @@ if (file.info(snp_file)$size == 0){
 		file.remove(paste0(outdir, "/", file))
 	}
 }
-

--- a/scripts/summarize.py
+++ b/scripts/summarize.py
@@ -8,6 +8,8 @@
 #########################################################################
 import os, sys, re
 import argparse
+import shutil
+import subprocess
 
 parser = argparse.ArgumentParser(description = "Summarize susie colocalization results.")
 parser.add_argument('-c', '--coverage', help="Coverage used in susie finemapping.", type=str, required=True)
@@ -45,6 +47,57 @@ def clean_up(precomp_dir, gwas_id):
         if re.search("eqtl_gwas_pair_file|eqtl_maf_finemap.list|eqtl_maf.list|gwas_maf_finemap.list|^coloc\.%s\.GWAS_split\..*\.eQTL_split.pairs$"%(gwas_id), file):
             os.system("rm %s"%(os.path.join(precomp_dir, file)))
 
+def awk_supports_strtonum():
+    awk_path = shutil.which("awk")
+    if awk_path is None:
+        return False
+    test = subprocess.run(
+        [awk_path, 'BEGIN{print strtonum("1")}'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True
+    )
+    return test.returncode == 0
+
+def filter_coloc_with_python(coloc_res, coloc_filter, coloc_cutoff):
+    with open(coloc_res, "r") as fin, open(coloc_filter, "w") as fout:
+        next(fin, None)
+        for line in fin:
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) < 13:
+                continue
+            try:
+                pph4 = float(fields[12])
+            except ValueError:
+                continue
+            if pph4 >= coloc_cutoff:
+                fout.write(line)
+
+def filter_coloc_with_awk(coloc_res, coloc_filter, coloc_cutoff):
+    with open(coloc_filter, "w") as fout:
+        run = subprocess.run(
+            ["awk", "-F", "\t", "strtonum($13) >= %f" % coloc_cutoff, coloc_res],
+            stdout=fout,
+            stderr=subprocess.PIPE,
+            text=True
+        )
+    return run.returncode == 0, run.stderr
+
+def filter_coloc_results(coloc_res, coloc_cutoff):
+    coloc_filter = coloc_res + ".PPH4." + str(coloc_cutoff)
+    # macOS default awk usually does not support gawk-only strtonum().
+    if sys.platform == "darwin" and not awk_supports_strtonum():
+        sys.stderr.write("awk strtonum unavailable on macOS, fallback to Python filter.\n")
+        filter_coloc_with_python(coloc_res, coloc_filter, coloc_cutoff)
+        return
+
+    ok, err = filter_coloc_with_awk(coloc_res, coloc_filter, coloc_cutoff)
+    if not ok:
+        sys.stderr.write("awk filter failed, fallback to Python filter.\n")
+        if err:
+            sys.stderr.write(err)
+        filter_coloc_with_python(coloc_res, coloc_filter, coloc_cutoff)
+
 ##################################
 precomp_dir = os.path.join(outdir, "precomputation")
 outdir = os.path.join(outdir, "COLOC")
@@ -62,6 +115,6 @@ for coverage in d_res_all:
             ff1.write("gwas_name\tgwas_info\teqtl_range\tensg\tcell\tnsnps\thit_eqtl\thit_gwas\tPP.H0.abf\tPP.H1.abf\tPP.H2.abf\tPP.H3.abf\tPP.H4.abf\tidx1\tidx2\n")
             for res in d_res_all[coverage]:
                 ff1.write("\t".join([str(j) for j in res])+"\n")
-    os.system("awk -F'\t' 'strtonum($13) >= %(coloc_cutoff)f' %(coloc_res)s > %(coloc_filter)s"%{"coloc_cutoff":coloc_cutoff, "coloc_res":coloc_res , "coloc_filter":coloc_res+".PPH4."+str(coloc_cutoff)})
+    filter_coloc_results(coloc_res, coloc_cutoff)
 
 clean_up(precomp_dir, gwas_id)

--- a/work_flow.snakefile
+++ b/work_flow.snakefile
@@ -36,10 +36,6 @@ THREADS = config['COLOC_SETTING']['THREADS']
 window_size = config['COLOC_SETTING']['WINDOW_SIZE_BP']
 COVERAGES = str(config['COLOC_SETTING']['COVERAGES']).split(",")
 COLOC_CUTOFF = config['COLOC_SETTING']['CUTOFF']
-IV_SELECTION = config.get('IV_SELECTION', {})
-EXPOSURE_P_THRESHOLD = str(IV_SELECTION.get('EXPOSURE_P_THRESHOLD', '5e-8'))
-CLUMP_P1 = str(IV_SELECTION.get('CLUMP_P1', '5e-8'))
-CLUMP_P2 = str(IV_SELECTION.get('CLUMP_P2', '0.01'))
 
 OUTCOME_DIR = config['OUTCOME_DIR']
 OUTCOMRS = [os.path.splitext(file)[0] for file in os.listdir(OUTCOME_DIR)]
@@ -239,12 +235,11 @@ rule snp_filter:
 		coloc_out = "{BASE_OUTPUT_DIR}/COLOC/Susie_coloc.{run_prefix}.results.coverage.{coverage}.PPH4.{coloc_cutoff}",
 		gwas_ma_file = lambda wildcards: GWAS_SUMSTATS[wildcards.run_prefix]['path'],
 		cells = ",".join(CELL_TYPES),
-		outdir = BASE_OUTPUT_DIR,
-		exposure_p_threshold = EXPOSURE_P_THRESHOLD
+		outdir = BASE_OUTPUT_DIR
 	#	conda:
 	#		"envs/envR4.yml"
 	shell:
-		"Rscript scripts/IV_select.r -r {params.coloc_out} -e {params.gwas_ma_file} -c {params.cells} -o {params.outdir} -p {params.exposure_p_threshold}"
+		"Rscript scripts/IV_select.r -r {params.coloc_out} -e {params.gwas_ma_file} -c {params.cells} -o {params.outdir}"
 
 rule clump:
 	input:
@@ -255,13 +250,11 @@ rule clump:
 		exp_ma_file = lambda wildcards: GWAS_SUMSTATS[wildcards.run_prefix]['path'],
 		snp_file = "{BASE_OUTPUT_DIR}/MR/Susie_coloc.{run_prefix}.results.coverage.{coverage}.PPH4.{coloc_cutoff}.{cell_type}.IV",
 		reference_genotype = GWAS_REFERENCE_PATH,
-		reference_dupliaction_path = GWAS_REFERENCE_DUP,
-		clump_p1 = CLUMP_P1,
-		clump_p2 = CLUMP_P2
+		reference_dupliaction_path = GWAS_REFERENCE_DUP
 	#	conda:
 	#		"envs/envR4.yml"
 	shell:
-		"Rscript scripts/clump.r -e {params.exp_ma_file} -s {params.snp_file} -r {params.reference_genotype} -d {params.reference_dupliaction_path} -p {params.clump_p1} -q {params.clump_p2}"
+		"Rscript scripts/clump.r -e {params.exp_ma_file} -s {params.snp_file} -r {params.reference_genotype} -d {params.reference_dupliaction_path}"
 
 rule MR:
 	input:

--- a/work_flow.snakefile
+++ b/work_flow.snakefile
@@ -36,6 +36,10 @@ THREADS = config['COLOC_SETTING']['THREADS']
 window_size = config['COLOC_SETTING']['WINDOW_SIZE_BP']
 COVERAGES = str(config['COLOC_SETTING']['COVERAGES']).split(",")
 COLOC_CUTOFF = config['COLOC_SETTING']['CUTOFF']
+IV_SELECTION = config.get('IV_SELECTION', {})
+EXPOSURE_P_THRESHOLD = str(IV_SELECTION.get('EXPOSURE_P_THRESHOLD', '5e-8'))
+CLUMP_P1 = str(IV_SELECTION.get('CLUMP_P1', '5e-8'))
+CLUMP_P2 = str(IV_SELECTION.get('CLUMP_P2', '0.01'))
 
 OUTCOME_DIR = config['OUTCOME_DIR']
 OUTCOMRS = [os.path.splitext(file)[0] for file in os.listdir(OUTCOME_DIR)]
@@ -235,11 +239,12 @@ rule snp_filter:
 		coloc_out = "{BASE_OUTPUT_DIR}/COLOC/Susie_coloc.{run_prefix}.results.coverage.{coverage}.PPH4.{coloc_cutoff}",
 		gwas_ma_file = lambda wildcards: GWAS_SUMSTATS[wildcards.run_prefix]['path'],
 		cells = ",".join(CELL_TYPES),
-		outdir = BASE_OUTPUT_DIR
-#	conda:
-#		"envs/envR4.yml"
+		outdir = BASE_OUTPUT_DIR,
+		exposure_p_threshold = EXPOSURE_P_THRESHOLD
+	#	conda:
+	#		"envs/envR4.yml"
 	shell:
-		"Rscript scripts/IV_select.r -r {params.coloc_out} -e {params.gwas_ma_file} -c {params.cells} -o {params.outdir}"
+		"Rscript scripts/IV_select.r -r {params.coloc_out} -e {params.gwas_ma_file} -c {params.cells} -o {params.outdir} -p {params.exposure_p_threshold}"
 
 rule clump:
 	input:
@@ -250,11 +255,13 @@ rule clump:
 		exp_ma_file = lambda wildcards: GWAS_SUMSTATS[wildcards.run_prefix]['path'],
 		snp_file = "{BASE_OUTPUT_DIR}/MR/Susie_coloc.{run_prefix}.results.coverage.{coverage}.PPH4.{coloc_cutoff}.{cell_type}.IV",
 		reference_genotype = GWAS_REFERENCE_PATH,
-		reference_dupliaction_path = GWAS_REFERENCE_DUP
-#	conda:
-#		"envs/envR4.yml"
+		reference_dupliaction_path = GWAS_REFERENCE_DUP,
+		clump_p1 = CLUMP_P1,
+		clump_p2 = CLUMP_P2
+	#	conda:
+	#		"envs/envR4.yml"
 	shell:
-		"Rscript scripts/clump.r -e {params.exp_ma_file} -s {params.snp_file} -r {params.reference_genotype} -d {params.reference_dupliaction_path}"
+		"Rscript scripts/clump.r -e {params.exp_ma_file} -s {params.snp_file} -r {params.reference_genotype} -d {params.reference_dupliaction_path} -p {params.clump_p1} -q {params.clump_p2}"
 
 rule MR:
 	input:


### PR DESCRIPTION
## Summary
- make coloc filtering robust when system awk does not support GNU awk `strtonum()`
- keep existing awk path when available
- add automatic Python fallback on macOS or any awk failure

## Problem
`scripts/summarize.py` used:

```bash
awk -F'\t' 'strtonum($13) >= cutoff' ...
```

On macOS default `/usr/bin/awk`, `strtonum()` is unavailable, which causes coloc summary filtering to fail and downstream MR outputs to become empty.

## Fix
- add `awk_supports_strtonum()` runtime check
- prefer original awk filter when supported
- fallback to Python filtering of column 13 (`PP.H4.abf`) when unsupported or awk execution fails

## Validation
- `python -m py_compile scripts/summarize.py`
- reran summarize step in a macOS environment and confirmed fallback message + non-empty `.PPH4.<cutoff>` output
